### PR TITLE
Update for Fontello icon

### DIFF
--- a/templates/default/content/syndication/icon/wordpress.tpl.php
+++ b/templates/default/content/syndication/icon/wordpress.tpl.php
@@ -1,0 +1,1 @@
+<i class="icon-wordpress"></i>


### PR DESCRIPTION
Adding a Wordpress brand icon.  You need to grab the latest core update with Fontello in External for this to work.
